### PR TITLE
Avoid undefined method errors when no sources have been added

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -85,6 +85,7 @@ end
 # sumo_source ran at compile time, because you ran the definition, didn't you?
 ruby_block 'compile_sumo_sources' do
   block do
+    node.run_state[:sumo_output] = []
     node.run_state[:sumo_output] =
       # Stupid hacky .to_s because Ruby 1.8 can't <=> symbols.
       node.run_state[:sumo_source].sort_by{ |k,v| k.to_s }.map do |k, v|
@@ -100,7 +101,7 @@ ruby_block 'compile_sumo_sources' do
       "category" : "#{v[:category]}"
     }
         EOS
-      end
+      end if node.run_state[:sumo_source]
   end
 end
 


### PR DESCRIPTION
Hi,

Following your docs, on RHEL 6, Chef 10.14.4 (embedded ruby 1.9.1), without configuring any sources, I got undefined method errors due to node.run_state[:sumo_source] being nil.  My fix was to make sure that node.run_state[:sumo_output] == [] and then skipping the original assignment in that case.

-Bryce.
