### PR TITLE
Dont use node attribute as default for resource attribute values

### DIFF
--- a/libraries/sumo_source_resource.rb
+++ b/libraries/sumo_source_resource.rb
@@ -23,11 +23,11 @@ class Chef
         set_or_return(:path, arg, :kind_of => String)
       end
 
-      def category(arg=node['sumologic']['sources']['default_category'])
+      def category(arg=nil)
         set_or_return(:default_timezone, arg, :kind_of => String)
       end
 
-      def default_timezone(arg= node['sumologic']['sources']['default_timezone'])
+      def default_timezone(arg=nil)
         set_or_return(:default_timezone, arg, :kind_of => String)
       end
 


### PR DESCRIPTION
global defaults are handled by installers. per resource overriding can be done via resource attributes
