### PR TITLE
add test-kitchen integration testing and deprecate Chef 10 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ Gemfile*.lock
 # .vagrant
 
 *.un~
-*.json
 vendor
 *.lock
+
+# Test kitchen
+.kitchen/
+.kitchen.local.yml
+cookbooks/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,36 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+
+platforms:
+# Loop through two lists and output a total matrix of all possible platform + chef versions
+<% %w(
+      ubuntu-14.04
+      ubuntu-12.04
+      ubuntu-10.04
+      centos-7.0
+      centos-6.6
+      centos-5.11
+    ).each do |platform_version| %>
+<% %w(
+      11.16.4
+      11.0.0
+    ).each do |chef_version| %>
+- name: <%= platform_version %>-<%= chef_version %>
+  driver:
+    box: opscode-<%= platform_version %>_chef
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_<%= platform_version %>_chef-provisionerless.box
+  provisioner:
+    require_chef_omnibus: <%= chef_version %>
+<% end %>
+<% end %>
+
+suites:
+- name: default
+  run_list:
+    - recipe[sumologic::default]
+  attributes:
+  data_bags_path: 'test/integration/data_bags'

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,7 +21,7 @@ platforms:
     ).each do |chef_version| %>
 - name: <%= platform_version %>-<%= chef_version %>
   driver:
-    box: opscode-<%= platform_version %>_chef
+    box: opscode-<%= platform_version %>
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_<%= platform_version %>_chef-provisionerless.box
   provisioner:
     require_chef_omnibus: <%= chef_version %>

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.1.3
-bundler_args: --binstubs --retry=5 --path=.bundle
+bundler_args: --binstubs --retry=5 --path=.bundle --without integration
 cache:
   directories:
     - .bundle

--- a/Berksfile
+++ b/Berksfile
@@ -2,4 +2,4 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'sumologic-collector', '= 1.2.1'
+cookbook 'sumologic-collector'

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,5 @@
-site :opscode
+source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'sumologic-collector'
+cookbook 'sumologic-collector', '= 1.2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,8 @@ group :development do
   gem 'webmock'
 end
 
+group :integration do
+  gem 'test-kitchen'
+  gem 'kitchen-vagrant'
+  gem 'berkshelf',  '~> 3.2.1'
+end

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ I suggest hosting it on a local asset server.
 Platform
 --------
 
-* Tested on Ubuntu 10.04, both x86 and x86-64.
-* Tested on Ubuntu 14.04, x86-64.
+* Tested on Ubuntu 10.04, 12.04, 14.04
+* Tested on CentOS 5.11, 6.6, 7.0
 * Will need extra work to run in Windows, Solaris.
-* Tested under Chef 0.10.8, Chef 10.12.0, and Chef 10.14.\*, in Ruby 1.9 and 2.1.3.
+* Tested under Chef 11.0.0 and 11.16.4 in Ruby 1.9 and 2.1.3.
 
 Attributes
 ==========

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,12 @@ task :spec do
   Rake::Task['spec'].invoke
 end
 
+desc 'Run all test kitchen combinations on the codebase'
+task :kitchen do
+  Rake::Task['berkshelf'].invoke
+  Rake::Task['kitchen:all'].invoke
+end
+
 desc 'Run foodcritic on all cookbooks'
 FoodCritic::Rake::LintTask.new do |t|
   t.options = {
@@ -33,6 +39,19 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = "--profile"
   t.pattern = %w{ spec/*.rb }
   t.fail_on_error = true
+end
+
+desc 'Install berkshelf cookbooks locally'
+task :berkshelf do |t, args|
+  system('bundle exec berks install')
+  system('bundle exec berks vendor cookbooks')
+end
+
+begin
+  require 'kitchen/rake_tasks'
+  Kitchen::RakeTasks.new
+rescue LoadError
+  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
 end
 
 task default: [:foodcritic, :rubocop, :spec]

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,6 @@
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'foodcritic'
-require 'berkshelf'
-require 'berkshelf/berksfile'
 
 desc 'Run all linters on the codebase'
 task :linters do
@@ -45,6 +43,8 @@ end
 
 desc 'Install berkshelf cookbooks locally'
 task :berkshelf do |t, args|
+  require 'berkshelf'
+  require 'berkshelf/berksfile'
   current_dir = File.expand_path('../', __FILE__)
   berksfile_path = File.join(current_dir, 'Berksfile')
   cookbooks_path = File.join(current_dir, 'cookbooks')

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'foodcritic'
+require 'berkshelf'
+require 'berkshelf/berksfile'
 
 desc 'Run all linters on the codebase'
 task :linters do
@@ -43,8 +45,12 @@ end
 
 desc 'Install berkshelf cookbooks locally'
 task :berkshelf do |t, args|
-  system('bundle exec berks install')
-  system('bundle exec berks vendor cookbooks')
+  current_dir = File.expand_path('../', __FILE__)
+  berksfile_path = File.join(current_dir, 'Berksfile')
+  cookbooks_path = File.join(current_dir, 'cookbooks')
+  berksfile = Berkshelf::Berksfile.from_file(berksfile_path)
+  FileUtils.rm_rf(cookbooks_path)
+  berksfile.vendor(cookbooks_path)
 end
 
 begin

--- a/test/integration/data_bags/sumo-creds/api-creds.json
+++ b/test/integration/data_bags/sumo-creds/api-creds.json
@@ -1,0 +1,5 @@
+{
+ "id": "api-creds",
+ "accessID": "example@example.com",
+ "accessKey": "password123"
+}


### PR DESCRIPTION
- Add test-kitchen testing for convergence on Ubuntu and Centos (include data bag for testing creds)
- Deprecate Chef 10 support (doesn't converge on Ubuntu 12.04 and CentOS 6.7)
- Pin sumologic-collector cookbook version due to bad release numbering (should be removed when v1.2.3 is released)