### PR TITLE
Fix spacing per new Rubocop rule

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -31,7 +31,7 @@ class Sumologic
     end
 
     def metadata
-      collectors['collectors'].find { |c|c['name'] == name }
+      collectors['collectors'].find { |c| c['name'] == name }
     end
 
     def exist?


### PR DESCRIPTION
Several new cops were added in the 0.29 update.  There was one violation which this fixes.