### PR TITLE
Allow custom installs of Sumologic Collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ See `attributes/default.rb` for default values.
   'sumocollector'.
 * `node[:sumologic][:disabled]` - Set this if you need to disable the collector
   on this node for some reason.
+* `node[:sumologic][:custom_install]` - Set this if you want to disable the default
+  collector install on this node for some reason.  This can be used if you need to
+  install the collector in a custom manner.  Default is false.
 * `node['sumologic']['api_timeout']` - Set a timeout for calls to the Sumologic API.
   Default is 60 seconds
 * `node[:sumologic][:collector][:version]` - The version of the collector you

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,3 +24,4 @@
 default['sumologic']['disabled'] = false
 default['sumologic']['log_sources']['default_category'] = 'log'
 default['sumologic']['api_timeout'] = 60
+default['sumologic']['custom_install'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,4 +19,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe 'sumologic-collector' unless node['sumologic']['disabled']
+include_recipe 'sumologic-collector' unless node['sumologic']['disabled'] ||
+                                            node['sumologic']['custom_install']


### PR DESCRIPTION
Adds an attribute to allow for custom installs.  This is useful if you want the functionality of the cookbook and its upstream, without the actual collector agent install.