### PR TITLE
Test under Chef 12, deprecate Ruby 1.9.3

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,6 +16,7 @@ platforms:
       centos-5.11
     ).each do |platform_version| %>
 <% %w(
+      12.1
       11.16.4
       11.0.0
     ).each do |chef_version| %>

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ branches:
     - master
 language: ruby
 rvm:
-  - 1.9.3
   - 2.1.5
   - 2.2.0
 bundler_args: --binstubs --retry=5 --path=.bundle --without integration

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rake'
 
 group :development do
   gem 'chefspec'
-  gem 'chef', '< 12.0.0'
+  gem 'chef'
   gem 'foodcritic'
   gem 'fuubar'
   gem 'pry'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Platform
 * Tested on Ubuntu 10.04, 12.04, 14.04
 * Tested on CentOS 5.11, 6.6, 7.0
 * Will need extra work to run in Windows, Solaris.
-* Tested under Chef 11.0.0 and 11.16.4 in Ruby 1.9 and 2.1.3.
+* Tested under Chef 11.0.0, 11.16.4, and 12.1 under Ruby 2.1.5 and 2.2.0.
 
 Attributes
 ==========


### PR DESCRIPTION
Ruby 1.9.3 is EOS and Chef 12 is Ruby 2+ only